### PR TITLE
v1.0.1 add custom pdf directory support

### DIFF
--- a/backend/process.js
+++ b/backend/process.js
@@ -68,7 +68,6 @@ const server = net.createServer(async (socket) => {
 				console.log('Neovim disconnected.'); 
 
 				let { stdout: KVTCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${WEBKIT_PORT}'  | sort) <(xdotool search --classname 'webkit_viewer.py'  | sort)"`); 
-				// await notify(KVTCommOut + " is the one to kill."); // Use stored KVTCommOut 
 				let KVTCommOutArray = KVTCommOut.split("\n");
 				for (pid of KVTCommOutArray) {
 					if (pid && pid.trim()) {
@@ -77,11 +76,9 @@ const server = net.createServer(async (socket) => {
 				}
 
 				let pdf_path = filepath;
-				await notify(KVTpdf_dir.lastIndexOf("/"));
 				if (KVTpdf_dir) {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
-					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
 					if (!(KVTpdf_dir.endsWith("/"))) {
 						KVTpdf_dir = KVTpdf_dir + "/";
@@ -89,21 +86,16 @@ const server = net.createServer(async (socket) => {
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {
 						// Absolute path
-						await notify("bus");
 						pdf_path = KVTpdf_dir + filepath.slice(lastSlash + 1);
 					} else {
 						// Relative path
-						await notify("sip");
 						pdf_path = filepath.slice(0, lastSlash + 1) + KVTpdf_dir + filepath.slice(lastSlash + 1);
-						await notify("hello");
 					}
 				}
 				// Change file extension to .pdf
 				pdf_path = pdf_path.slice(0, -3) + "pdf";
-				await notify(pdf_path);
 
 				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${pdf_path}'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 
-				// await notify(ZathuraCommOut + " is the one to kill."); // Use stored ZathuraCommOut 
 				let ZathuraCommOutArray = ZathuraCommOut.split("\n");
 				for (pid of ZathuraCommOutArray) {
 					if (pid && pid.trim()) {
@@ -112,7 +104,6 @@ const server = net.createServer(async (socket) => {
 				}
 
 			} catch (error) {
-				// await notify(`Error in socket.on('end'): ${error.message}`); 
 				console.error(`Error in socket.on('end'): ${error.message}`); 
 			}
 		}); 

--- a/backend/process.js
+++ b/backend/process.js
@@ -82,10 +82,12 @@ const server = net.createServer(async (socket) => {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
 					await notify(lastSlash);	
+					/*
 					// Ensure KVTpdf_dir ends with a slash
 					if (!(KVTpdf_dir.slice(-1) === "/")) {
 						KVTpdf_dir += "/";
 					}
+					*/
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {
 						// Absolute path

--- a/backend/process.js
+++ b/backend/process.js
@@ -93,6 +93,7 @@ const server = net.createServer(async (socket) => {
 					} else {
 						// Relative path
 						pdf_path = filepath.slice(0, lastSlash + 1) + KVTpdf_dir + filepath.slice(lastSlash + 1);
+						await notify("hello")
 					}
 				}
 				// Change file extension to .pdf

--- a/backend/process.js
+++ b/backend/process.js
@@ -67,9 +67,6 @@ const server = net.createServer(async (socket) => {
 			try {
 				console.log('Neovim disconnected.'); 
 
-				// render.terminateViewer(WEBKIT_PORT); this is too finnicky
-				
-
 				let { stdout: KVTCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${WEBKIT_PORT}'  | sort) <(xdotool search --classname 'webkit_viewer.py'  | sort)"`); 
 				// await notify(KVTCommOut + " is the one to kill."); // Use stored KVTCommOut 
 				let KVTCommOutArray = KVTCommOut.split("\n");
@@ -101,6 +98,7 @@ const server = net.createServer(async (socket) => {
 				}
 				// Change file extension to .pdf
 				pdf_path = pdf_path.slice(0, -3) + "pdf";
+				await notify(pdf_path);
 
 				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${pdf_path}'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 
 				// await notify(ZathuraCommOut + " is the one to kill."); // Use stored ZathuraCommOut 

--- a/backend/process.js
+++ b/backend/process.js
@@ -81,7 +81,7 @@ const server = net.createServer(async (socket) => {
 				if (KVTpdf_dir) {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
-					
+					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
 					if (KVTpdf_dir.slice(-1) !== "/") {
 						KVTpdf_dir += "/";

--- a/backend/process.js
+++ b/backend/process.js
@@ -85,6 +85,7 @@ const server = net.createServer(async (socket) => {
 					// Ensure KVTpdf_dir ends with a slash
 					if (KVTpdf_dir.slice(-1) !== "/") {
 						KVTpdf_dir += "/";
+						await notify("11");
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {

--- a/backend/process.js
+++ b/backend/process.js
@@ -6,7 +6,7 @@ const { exec } = require('child_process');
 
 const KVTRoot = process.argv[2];
 const filepath = process.argv[5];
-const KVTpdf_dir = process.argv[6];
+var KVTpdf_dir = process.argv[6];
 
 const newcommands_file = KVTRoot + "/backend/resources/aliases.txt";
 const kill_script_path = KVTRoot + "/backend/kill_processes.sh";

--- a/backend/process.js
+++ b/backend/process.js
@@ -77,7 +77,7 @@ const server = net.createServer(async (socket) => {
 				}
 
 				let pdf_path = filepath;
-
+				await notify(pdf_path);
 				if (KVTpdf_dir) {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
@@ -98,7 +98,6 @@ const server = net.createServer(async (socket) => {
 				}
 				// Change file extension to .pdf
 				pdf_path = pdf_path.slice(0, -3) + "pdf";
-				await notify("hello")
 				await notify(pdf_path);
 
 				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${pdf_path}'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 

--- a/backend/process.js
+++ b/backend/process.js
@@ -86,7 +86,7 @@ const server = net.createServer(async (socket) => {
 					if (KVTpdf_dir.slice(-1) !== "/") {
 						KVTpdf_dir += "/";
 					}
-
+					await notify(lastSlash);
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) === "/") {
 						// Absolute path

--- a/backend/process.js
+++ b/backend/process.js
@@ -84,7 +84,7 @@ const server = net.createServer(async (socket) => {
 					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
 					if (!(KVTpdf_dir.endsWith("/"))) {
-						KVTpdf_dir += "/";
+						// KVTpdf_dir += "/";
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {

--- a/backend/process.js
+++ b/backend/process.js
@@ -92,6 +92,7 @@ const server = net.createServer(async (socket) => {
 						pdf_path = KVTpdf_dir + filepath.slice(lastSlash + 1);
 					} else {
 						// Relative path
+						await notify("sip")
 						pdf_path = filepath.slice(0, lastSlash + 1) + KVTpdf_dir + filepath.slice(lastSlash + 1);
 						await notify("hello")
 					}

--- a/backend/process.js
+++ b/backend/process.js
@@ -84,7 +84,7 @@ const server = net.createServer(async (socket) => {
 					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
 					if (!(KVTpdf_dir.endsWith("/"))) {
-						// KVTpdf_dir += "/";
+						KVTpdf_dir = KVTpdf_dir + "/";
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {

--- a/backend/process.js
+++ b/backend/process.js
@@ -83,9 +83,8 @@ const server = net.createServer(async (socket) => {
 					let lastSlash = filepath.lastIndexOf("/");
 					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
-					if (KVTpdf_dir.slice(-1) !== "/") {
+					if !(KVTpdf_dir.slice(-1) === "/") {
 						KVTpdf_dir += "/";
-						await notify("11");
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {

--- a/backend/process.js
+++ b/backend/process.js
@@ -87,14 +87,15 @@ const server = net.createServer(async (socket) => {
 						KVTpdf_dir += "/";
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
-					if (KVTpdf_dir.slice(0, 1) === "/") {
+					if (KVTpdf_dir.slice(0, 1) == "/") {
 						// Absolute path
+						await notify("bus");
 						pdf_path = KVTpdf_dir + filepath.slice(lastSlash + 1);
 					} else {
 						// Relative path
-						await notify("sip")
+						await notify("sip");
 						pdf_path = filepath.slice(0, lastSlash + 1) + KVTpdf_dir + filepath.slice(lastSlash + 1);
-						await notify("hello")
+						await notify("hello");
 					}
 				}
 				// Change file extension to .pdf

--- a/backend/process.js
+++ b/backend/process.js
@@ -82,12 +82,10 @@ const server = net.createServer(async (socket) => {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
 					await notify(lastSlash);	
-					/*
 					// Ensure KVTpdf_dir ends with a slash
-					if (!(KVTpdf_dir.slice(-1) === "/")) {
+					if (!(KVTpdf_dir.endsWith("/"))) {
 						KVTpdf_dir += "/";
 					}
-					*/
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) == "/") {
 						// Absolute path

--- a/backend/process.js
+++ b/backend/process.js
@@ -77,7 +77,7 @@ const server = net.createServer(async (socket) => {
 				}
 
 				let pdf_path = filepath;
-				await notify(KVTpdf_dir);
+				await notify(KVTpdf_dir.lastIndexOf("/"));
 				if (KVTpdf_dir) {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");
@@ -86,7 +86,6 @@ const server = net.createServer(async (socket) => {
 					if (KVTpdf_dir.slice(-1) !== "/") {
 						KVTpdf_dir += "/";
 					}
-					await notify(lastSlash);
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
 					if (KVTpdf_dir.slice(0, 1) === "/") {
 						// Absolute path

--- a/backend/process.js
+++ b/backend/process.js
@@ -98,6 +98,7 @@ const server = net.createServer(async (socket) => {
 				}
 				// Change file extension to .pdf
 				pdf_path = pdf_path.slice(0, -3) + "pdf";
+				await notify("hello")
 				await notify(pdf_path);
 
 				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${pdf_path}'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 

--- a/backend/process.js
+++ b/backend/process.js
@@ -77,7 +77,7 @@ const server = net.createServer(async (socket) => {
 				}
 
 				let pdf_path = filepath;
-				await notify(pdf_path);
+				await notify(KVTpdf_dir);
 				if (KVTpdf_dir) {
 					// Find the last slash in the filepath
 					let lastSlash = filepath.lastIndexOf("/");

--- a/backend/process.js
+++ b/backend/process.js
@@ -83,7 +83,7 @@ const server = net.createServer(async (socket) => {
 					let lastSlash = filepath.lastIndexOf("/");
 					await notify(lastSlash);	
 					// Ensure KVTpdf_dir ends with a slash
-					if !(KVTpdf_dir.slice(-1) === "/") {
+					if (!(KVTpdf_dir.slice(-1) === "/")) {
 						KVTpdf_dir += "/";
 					}
 					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative

--- a/backend/process.js
+++ b/backend/process.js
@@ -6,6 +6,7 @@ const { exec } = require('child_process');
 
 const KVTRoot = process.argv[2];
 const filepath = process.argv[5];
+const KVTpdf_dir = process.argv[6];
 
 const newcommands_file = KVTRoot + "/backend/resources/aliases.txt";
 const kill_script_path = KVTRoot + "/backend/kill_processes.sh";
@@ -78,7 +79,30 @@ const server = net.createServer(async (socket) => {
 					}
 				}
 
-				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${filepath.slice(0,-3)}pdf'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 
+				let pdf_path = filepath;
+
+				if (KVTpdf_dir) {
+					// Find the last slash in the filepath
+					let lastSlash = filepath.lastIndexOf("/");
+					
+					// Ensure KVTpdf_dir ends with a slash
+					if (KVTpdf_dir.slice(-1) !== "/") {
+						KVTpdf_dir += "/";
+					}
+
+					// Construct the new pdf_path based on whether KVTpdf_dir is absolute or relative
+					if (KVTpdf_dir.slice(0, 1) === "/") {
+						// Absolute path
+						pdf_path = KVTpdf_dir + filepath.slice(lastSlash + 1);
+					} else {
+						// Relative path
+						pdf_path = filepath.slice(0, lastSlash + 1) + KVTpdf_dir + filepath.slice(lastSlash + 1);
+					}
+				}
+				// Change file extension to .pdf
+				pdf_path = pdf_path.slice(0, -3) + "pdf";
+
+				let { stdout: ZathuraCommOut } = await execAsync(`bash -c "comm -12 <(xdotool search --name  '${pdf_path}'  | sort) <(xdotool search --classname 'zathura'  | sort)"`); 
 				// await notify(ZathuraCommOut + " is the one to kill."); // Use stored ZathuraCommOut 
 				let ZathuraCommOutArray = ZathuraCommOut.split("\n");
 				for (pid of ZathuraCommOutArray) {

--- a/backend/resources/i3/bashrc
+++ b/backend/resources/i3/bashrc
@@ -25,6 +25,6 @@ KVTremap="xdotool windowmap '$kitty_window_id'"
 # Execute Neovim commands
 KVTnvimcommand='nvim -c "KVTServer" -c "VimtexCompile" -c "redraw!"'
 
-alias vimtex="i3-msg append_layout $KVTlayout_path && $KVTunmap && $KVTremap && $KVTnvimcommand"
+alias vimtex="i3-msg append_layout $KVTlayout_path > /dev/null && $KVTunmap && $KVTremap && $KVTnvimcommand"
 
 # END OF KaVimTeX

--- a/lua/vim_server/start_server.lua
+++ b/lua/vim_server/start_server.lua
@@ -7,6 +7,12 @@ local KVTRoot = "" -- after it is found, it will *not* contain a / after KaVimTe
 local FILENAME = vim.api.nvim_buf_get_name(0)
 
 
+local KVTpdf_dir = ""
+
+if vim.g.KVTpdf_dir then
+	KVTpdf_dir=vim.g.KVTpdf_dir
+end
+
 local function get_free_port()
 	local server = socket.tcp()
   	server:setoption("reuseaddr", true) -- Allow reusing the address
@@ -107,7 +113,7 @@ end
 
 local function run_script(interpreter, script_path)
 	if vim.fn.filereadable(script_path) == 1 then
-		local cmd = {interpreter, script_path, KVTRoot, WEBKIT_PORT, PROCESS_PORT, FILENAME }
+		local cmd = {interpreter, script_path, KVTRoot, WEBKIT_PORT, PROCESS_PORT, FILENAME, KVTpdf_dir }
 		vim.fn.jobstart(cmd, {detach = true})
 	else
     	print("File not found: " .. script_path)


### PR DESCRIPTION
to kill zathura when a different pdf output directory is set, just set `g.KVTpdf_dir` to whatever the `absolute` (with a leading `/`) or `relative` (no leading `/`) directory where your pdf file will be; the pdf file must have the same filename as the .tex. 